### PR TITLE
Improve 'Libs*' fields in pkg-config file

### DIFF
--- a/config/libtuv.pc.in
+++ b/config/libtuv.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: libtuv
 Description: Asynchronous I/O for embedded system
 Version: 1.0.0
-Libs: -L${libdir} -lpthread
+Libs: -L${libdir} -ltuv
+Libs.private: -lpthread
 Cflags: -I${includedir}/libtuv


### PR DESCRIPTION
- `Libs` should contain `-ltuv`, i.e., libtuv itself, as a
  necessary linker flag.
- The dependency libpthread is better added to `Libs.private` to
  avoid overlinking.

libtuv-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu