### PR TITLE
Define SOMAXCONN if that is not defined earlier.

### DIFF
--- a/include/uv-nuttx.h
+++ b/include/uv-nuttx.h
@@ -98,11 +98,13 @@ ssize_t writev(int __fd, const struct iovec* __iovec, int __count);
 int getpeername(int sockfd, struct sockaddr* addr, socklen_t* addrlen);
 
 // Maximum queue length specifiable by listen
+#ifndef SOMAXCONN
 #define SOMAXCONN 8
+#endif
 
 //-----------------------------------------------------------------------------
-// structure extension for nuttx                                                          
-//                                                                                        
+// structure extension for nuttx
+//
 #define UV_PLATFORM_LOOP_FIELDS                                               \
   struct pollfd pollfds[TUV_POLL_EVENTS_SIZE];                                \
   int npollfds;                                                               \


### PR DESCRIPTION
Added a preprocessor guard for SOMAXCONN since NuttX-7.27 already defines that by [this commit](https://bitbucket.org/nuttx/nuttx/commits/f036e2a32a4039907f6b420abd84c1361e37a36d) (2018-11-09).
