### PR TITLE
libtuv: Add support for stm32f7nucleo board

### DIFF
--- a/cmake/option/option_arm-nuttx.cmake
+++ b/cmake/option/option_arm-nuttx.cmake
@@ -40,6 +40,14 @@ if(DEFINED TARGET_BOARD)
           "-mfpu=fpv4-sp-d16"
           "-mfloat-abi=hard"
           )
+  elseif(${TARGET_BOARD} STREQUAL "stm32f7nucleo")
+    set(FLAGS_COMMON
+          ${FLAGS_COMMON}
+          "-mcpu=cortex-m7"
+          "-mthumb"
+          "-march=armv7e-m"
+          "-mfloat-abi=hard"
+         )
   else()
     message(FATAL_ERROR "TARGET_BOARD=`${TARGET_BOARD}` is unknown to make")
   endif()


### PR DESCRIPTION
ARM Cortext M7 has at least all features of M4,
but -mfpu flag is not needed
as it will be guessed from -mcpu settings.

It was tested on Nucleo-767ZI.

Change-Id: Ie825b1728eb9373e311086153aa28bdcf42c7c76
libtuv-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com