### PR TITLE
Fixed 'function declaration is not a prototype' compiler warnings.

### DIFF
--- a/include/tuv__debuglog.h
+++ b/include/tuv__debuglog.h
@@ -99,8 +99,8 @@ extern "C" {
 #endif
 
 
-void InitDebugSettings();
-void ReleaseDebugSettings();
+void InitDebugSettings(void);
+void ReleaseDebugSettings(void);
 
 
 #ifdef __cplusplus

--- a/src/tuv_debuglog.c
+++ b/src/tuv_debuglog.c
@@ -31,7 +31,7 @@ const char* tuv_debug_prefix[4] = { "", "ERR", "WRN", "INF" };
 #endif // ENABLE_DEBUG_LOG
 
 
-void InitDebugSettings() {
+void InitDebugSettings(void) {
 #ifdef ENABLE_DEBUG_LOG
   const char* dbglevel = NULL;
   const char* dbglogfile = NULL;
@@ -59,7 +59,7 @@ void InitDebugSettings() {
 }
 
 
-void ReleaseDebugSettings() {
+void ReleaseDebugSettings(void) {
 #ifdef ENABLE_DEBUG_LOG
   if (tuv_log_stream != stderr && tuv_log_stream != stdout) {
     fclose(tuv_log_stream);


### PR DESCRIPTION
libtuv-DCO-1.0-Signed-off-by: Laszlo Lango llango.u-szeged@partner.samsung.com